### PR TITLE
Fix `clangFirstWord` when the selector name starts with uppercase let…

### DIFF
--- a/src/main/java/org/moe/natjgen/ObjCMethod.java
+++ b/src/main/java/org/moe/natjgen/ObjCMethod.java
@@ -532,20 +532,11 @@ public class ObjCMethod extends AbstractModelElement implements IParameterizedCa
      * @return selector's first word
      */
     public static String clangFirstWord(String selector, int start) {
-        int loc = start;
+        int loc = start + 1;
         while (loc < selector.length()) {
             char c = selector.charAt(loc);
             if (Character.isUpperCase(c) || c == ':') break;
             ++loc;
-        }
-
-        if (loc == 0) {
-            while (loc < selector.length()) {
-                char c = selector.charAt(loc);
-                if (Character.isLowerCase(c) || c == ':') break;
-                ++loc;
-            }
-            if (loc != selector.length()) --loc;
         }
 
         return selector.substring(start, loc);

--- a/src/test/java/org/moe/natjgen/ObjCMethodTest.java
+++ b/src/test/java/org/moe/natjgen/ObjCMethodTest.java
@@ -5,10 +5,18 @@ import junit.framework.TestCase;
 public class ObjCMethodTest extends TestCase {
 
     public void testClangFirstWord() {
+        assertEquals("i", ObjCMethod.clangFirstWord("i", 0));
+
         assertEquals("init", ObjCMethod.clangFirstWord("init", 0));
         assertEquals("init", ObjCMethod.clangFirstWord("initWithString", 0));
 
         assertEquals("opy", ObjCMethod.clangFirstWord("mutableCopyWithSomething", "mutableC".length()));
         assertEquals("opywith", ObjCMethod.clangFirstWord("mutableCopywithSomething", "mutableC".length()));
+    }
+
+    public void testClangFirstWordStartWithUpperCase() {
+        assertEquals("Visible", ObjCMethod.clangFirstWord("VisibleDropDown", 0));
+        assertEquals("Drop", ObjCMethod.clangFirstWord("VisibleDropDown", "Visible".length()));
+        assertEquals("I", ObjCMethod.clangFirstWord("IVisibleDropDown", 0));
     }
 }


### PR DESCRIPTION
…ter (multi-os-engine/multi-os-engine#144)