### PR TITLE
Improve deprecated information and add Introduced-API information

### DIFF
--- a/src/main/java/org/moe/natjgen/ClangUtil.java
+++ b/src/main/java/org/moe/natjgen/ClangUtil.java
@@ -388,21 +388,18 @@ public final class ClangUtil {
         String since = getSinceVersion(decl, platform);
         String sinceDeprecated = getDeprecatedVersion(decl, platform);
         String deprecatedMessage = getDeprecatedMessage(decl, platform);
+        String returnString = "";
         try {
             CXString s = clang_Cursor_getRawCommentText(decl);
             String rawComment = s == null ? null : s.getCString();
             if (rawComment != null) {
-//                System.out.println(rawComment);
+                // Add a extra newline if a comment is available
                 if (since != null || sinceDeprecated != null || deprecatedMessage != null) rawComment += "\n";
-                if (since != null) rawComment += "\nAPI-Since: " + since;
-                if (sinceDeprecated != null) rawComment += "\nDeprecated-Since: " + sinceDeprecated;
-                if (deprecatedMessage != null) rawComment += "\nDeprecated-Message: " + deprecatedMessage;
-                return rawComment;
+                returnString = rawComment;
             }
         } catch (Exception ex) {
             ex.printStackTrace();
         }
-        String returnString = "";
         if (since != null) returnString += "\nAPI-Since: " + since;
         if (sinceDeprecated != null) returnString += "\nDeprecated-Since: " + sinceDeprecated;
         if (deprecatedMessage != null) returnString += "\nDeprecated-Message: " + deprecatedMessage;

--- a/src/main/java/org/moe/natjgen/ClangUtil.java
+++ b/src/main/java/org/moe/natjgen/ClangUtil.java
@@ -25,6 +25,7 @@ import org.clang.enums.CX_StorageClass;
 import org.clang.opaque.CXTranslationUnit;
 import org.clang.struct.CXCursor;
 import org.clang.struct.CXIdxDeclInfo;
+import org.clang.struct.CXPlatformAvailability;
 import org.clang.struct.CXSourceLocation;
 import org.clang.struct.CXSourceRange;
 import org.clang.struct.CXString;
@@ -230,10 +231,67 @@ public final class ClangUtil {
      * Tells whether an element at the given cursor is deprecated or not
      *
      * @param c cursor
-     * @return true when deprecated otherwise false
+     * @param platform Platform to check for deprecation
      */
-    public static boolean isDeprecated(CXCursor c) {
-        return c.getCursorAvailability() == CXAvailabilityKind.Deprecated;
+    public static boolean isDeprecated(CXCursor c, String platform) {
+        return getDeprecatedVersion(c, platform) != null;
+    }
+
+    /**
+     * Returns the Introduced since property
+     *
+     * @param c cursor
+     * @param platform Platform to check for property
+     * @return the version since the element exist, otherwise null
+     */
+    public static String getSinceVersion(CXCursor c, String platform) {
+        CXPlatformAvailability[] availabilities = c.getCursorPlatformAvailabilities();
+        for (CXPlatformAvailability availability : availabilities) {
+            if (!availability.Platform().toString().equalsIgnoreCase(platform))
+                continue;
+            if (!availability.Introduced().toString().isEmpty()) {
+                return availability.Introduced().toString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the Deprecated since property
+     *
+     * @param c cursor
+     * @param platform Platform to check for property
+     * @return the version since the element is deprecated, otherwise null
+     */
+    public static String getDeprecatedVersion(CXCursor c, String platform) {
+        CXPlatformAvailability[] availabilities = c.getCursorPlatformAvailabilities();
+        for (CXPlatformAvailability availability : availabilities) {
+            if (!availability.Platform().toString().equalsIgnoreCase(platform))
+                continue;
+            if (!availability.Deprecated().toString().isEmpty()) {
+                return availability.Deprecated().toString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the Deprecated message property
+     *
+     * @param c cursor
+     * @param platform Platform to check for property
+     * @return the deprecated message if the element is deprecated, otherwise null
+     */
+    public static String getDeprecatedMessage(CXCursor c, String platform) {
+        CXPlatformAvailability[] availabilities = c.getCursorPlatformAvailabilities();
+        for (CXPlatformAvailability availability : availabilities) {
+            if (!availability.Platform().toString().equalsIgnoreCase(platform))
+                continue;
+            if (!availability.Message().toString().isEmpty()) {
+                return availability.Message().toString();
+            }
+        }
+        return null;
     }
 
     public static String nameForLinkage(int linkage) {
@@ -326,18 +384,28 @@ public final class ClangUtil {
         return parameters;
     }
 
-    public static String getComment(CXCursor decl) {
+    public static String getComment(CXCursor decl, String platform) {
+        String since = getSinceVersion(decl, platform);
+        String sinceDeprecated = getDeprecatedVersion(decl, platform);
+        String deprecatedMessage = getDeprecatedMessage(decl, platform);
         try {
             CXString s = clang_Cursor_getRawCommentText(decl);
             String rawComment = s == null ? null : s.getCString();
             if (rawComment != null) {
 //                System.out.println(rawComment);
+                if (since != null || sinceDeprecated != null || deprecatedMessage != null) rawComment += "\n";
+                if (since != null) rawComment += "\nAPI-Since: " + since;
+                if (sinceDeprecated != null) rawComment += "\nDeprecated-Since: " + sinceDeprecated;
+                if (deprecatedMessage != null) rawComment += "\nDeprecated-Message: " + deprecatedMessage;
                 return rawComment;
             }
         } catch (Exception ex) {
             ex.printStackTrace();
         }
-
-        return null;
+        String returnString = "";
+        if (since != null) returnString += "\nAPI-Since: " + since;
+        if (sinceDeprecated != null) returnString += "\nDeprecated-Since: " + sinceDeprecated;
+        if (deprecatedMessage != null) returnString += "\nDeprecated-Message: " + deprecatedMessage;
+        return returnString.isEmpty() ? null : returnString;
     }
 }

--- a/src/main/java/org/moe/natjgen/Indexer.java
+++ b/src/main/java/org/moe/natjgen/Indexer.java
@@ -555,7 +555,7 @@ public class Indexer {
                 if (cat_manager == null) {
                     cat_manager = new ObjCExternalCategoryManager(this, name_fq, cls_manager);
                     cat_manager.setLibraryName(unit.getFramework());
-                    cat_manager.setComment(ClangUtil.getComment(container));
+                    cat_manager.setComment(ClangUtil.getComment(container, configuration.getPlatform()));
                     generator.put(name_fq, cat_manager);
                 }
                 return cat_manager;

--- a/src/main/java/org/moe/natjgen/ModelBuilder.java
+++ b/src/main/java/org/moe/natjgen/ModelBuilder.java
@@ -333,9 +333,6 @@ class ModelBuilder extends AbstractModelEditor {
         final ObjCMethod getter = new ObjCMethod(getter_info.cursor().toString(), isStatic, new Type(type, memModel), 0,
                 ObjCMethodKind.PROPERTY_GETTER, false, manager);
         getter.close();
-        if (getter.getJavaName().equals("prop_1")) {
-            System.out.println("jaa");
-        }
         getter.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
         getter.setPropertyName(name);
         getter.setAttribute(attrInfo);

--- a/src/main/java/org/moe/natjgen/ModelBuilder.java
+++ b/src/main/java/org/moe/natjgen/ModelBuilder.java
@@ -82,9 +82,9 @@ class ModelBuilder extends AbstractModelEditor {
                 supername, clang_Cursor_getObjCRuntimeName(declCursor).toString());
         manager.setExternalUnit(unit.handlingExternal());
         manager.setLibraryName(unit.getFramework());
-        manager.setDeprecated(ClangUtil.isDeprecated(declCursor));
+        manager.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
         manager.setHybridClass(unit.generateHybridClass());
-        manager.setComment(ClangUtil.getComment(declCursor));
+        manager.setComment(ClangUtil.getComment(declCursor, indexer.getConfiguration().getPlatform()));
 
         boolean typeParamsFailed = false;
         int numOLG = clang.clang_Cursor_getNumObjCGenericParams(declCursor);
@@ -206,8 +206,8 @@ class ModelBuilder extends AbstractModelEditor {
                 clang_Cursor_getObjCRuntimeName(declCursor).toString());
         manager.setExternalUnit(unit.handlingExternal());
         manager.setLibraryName(unit.getFramework());
-        manager.setDeprecated(ClangUtil.isDeprecated(declCursor));
-        manager.setComment(ClangUtil.getComment(declCursor));
+        manager.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
+        manager.setComment(ClangUtil.getComment(declCursor, indexer.getConfiguration().getPlatform()));
 
         // Add protocols
         final CXIdxObjCProtocolRefListInfo info = decl.getObjCProtocolRefListInfo();
@@ -272,9 +272,9 @@ class ModelBuilder extends AbstractModelEditor {
             method.getArguments().add(new CalleeArgument(name, new Type(type, memModel, argCursor)));
         }
         method.close();
-        method.setDeprecated(ClangUtil.isDeprecated(declCursor));
+        method.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
         method.setAttribute(attrInfo);
-        method.setComment(ClangUtil.getComment(declCursor));
+        method.setComment(ClangUtil.getComment(declCursor, indexer.getConfiguration().getPlatform()));
 
         // Skip if needed
         if (unit.handlingExternal()) {
@@ -327,13 +327,16 @@ class ModelBuilder extends AbstractModelEditor {
         final int propertyFlags = clang_Cursor_getObjCPropertyAttributes(declCursor, 0);
         final boolean isStatic = (propertyFlags & CXObjCPropertyAttrKind.CXObjCPropertyAttr_class) > 0;
 
-        final String comment = ClangUtil.getComment(declCursor);
+        final String comment = ClangUtil.getComment(declCursor, indexer.getConfiguration().getPlatform());
 
         // Create getter
         final ObjCMethod getter = new ObjCMethod(getter_info.cursor().toString(), isStatic, new Type(type, memModel), 0,
                 ObjCMethodKind.PROPERTY_GETTER, false, manager);
         getter.close();
-        getter.setDeprecated(ClangUtil.isDeprecated(declCursor));
+        if (getter.getJavaName().equals("prop_1")) {
+            System.out.println("jaa");
+        }
+        getter.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
         getter.setPropertyName(name);
         getter.setAttribute(attrInfo);
         getter.setPropertyFlags(propertyFlags);
@@ -353,7 +356,7 @@ class ModelBuilder extends AbstractModelEditor {
                     ObjCMethodKind.PROPERTY_SETTER, false, manager);
             setter.getArguments().add(new CalleeArgument("value", new Type(type, memModel)));
             setter.close();
-            setter.setDeprecated(ClangUtil.isDeprecated(declCursor));
+            setter.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
             setter.setPropertyName(name);
             setter.setAttribute(attrInfo);
             setter.setPropertyFlags(propertyFlags);
@@ -405,7 +408,7 @@ class ModelBuilder extends AbstractModelEditor {
                 decl.entityInfo().USR());
         manager.setExternalUnit(unit.handlingExternal());
         manager.setAlignment(decl.cursor().getCursorType().getAlignOf());
-        manager.setDeprecated(ClangUtil.isDeprecated(decl.cursor()));
+        manager.setDeprecated(ClangUtil.isDeprecated(decl.cursor(), indexer.getConfiguration().getPlatform()));
         getGenerator().put(decl.entityInfo().USR(), manager);
     }
 
@@ -423,8 +426,8 @@ class ModelBuilder extends AbstractModelEditor {
         if (fieldname != null) {
             final CStructField field = new CStructField(fieldname, new Type(decl.cursor().getCursorType(), memModel),
                     decl.cursor().isBitField());
-            field.setDeprecated(ClangUtil.isDeprecated(decl.cursor()));
-            field.setComment(ClangUtil.getComment(decl.cursor()));
+            field.setDeprecated(ClangUtil.isDeprecated(decl.cursor(), indexer.getConfiguration().getPlatform()));
+            field.setComment(ClangUtil.getComment(decl.cursor(), indexer.getConfiguration().getPlatform()));
             if (field.getConstantArraySize() > 0) {
                 struct.getFields().add(field);
             }
@@ -459,8 +462,8 @@ class ModelBuilder extends AbstractModelEditor {
         if (getGenerator().getEnum(unitKey) == null) {
             CEnumManager manager = new CEnumManager(indexer, unit.getFQName(), unit.getOriginalName(), unit.getPath());
             manager.setExternalUnit(unit.handlingExternal());
-            manager.setDeprecated(ClangUtil.isDeprecated(decl.cursor()));
-            manager.setComment(ClangUtil.getComment(decl.cursor()));
+            manager.setDeprecated(ClangUtil.isDeprecated(decl.cursor(), indexer.getConfiguration().getPlatform()));
+            manager.setComment(ClangUtil.getComment(decl.cursor(), indexer.getConfiguration().getPlatform()));
             getGenerator().put(unitKey, manager);
         }
     }
@@ -502,8 +505,8 @@ class ModelBuilder extends AbstractModelEditor {
         if (manager != null) {
             ConstantValue constantValue = ConstantValue.fromSignExtendedValue(const_type, const_value);
             CEnumConstant constant = new CEnumConstant(const_name, constantValue);
-            constant.setDeprecated(ClangUtil.isDeprecated(declCursor));
-            constant.setComment(ClangUtil.getComment(declCursor));
+            constant.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
+            constant.setComment(ClangUtil.getComment(declCursor, indexer.getConfiguration().getPlatform()));
 
             manager.getConstants().add(constant);
         } else {
@@ -578,8 +581,8 @@ class ModelBuilder extends AbstractModelEditor {
             function.getArguments().add(new CalleeArgument(name, new Type(type, memModel, argCursor)));
         }
         function.close();
-        function.setDeprecated(ClangUtil.isDeprecated(declCursor));
-        function.setComment(ClangUtil.getComment(declCursor));
+        function.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
+        function.setComment(ClangUtil.getComment(declCursor, indexer.getConfiguration().getPlatform()));
 
         // Add function to manager
         final CManager manager = getGenerator().getCManager(indexer, unit);
@@ -640,8 +643,8 @@ class ModelBuilder extends AbstractModelEditor {
             }
             variable.setValue(ConstantValue.fromRawValue(variable.getType(), val.getValue()));
         }
-        variable.setDeprecated(ClangUtil.isDeprecated(declCursor));
-        variable.setComment(ClangUtil.getComment(declCursor));
+        variable.setDeprecated(ClangUtil.isDeprecated(declCursor, indexer.getConfiguration().getPlatform()));
+        variable.setComment(ClangUtil.getComment(declCursor, indexer.getConfiguration().getPlatform()));
 
         // Add variable to manager
         final CManager manager = getGenerator().getCManager(indexer, unit);


### PR DESCRIPTION
This fixes:
- When deprecation target was higher than the deployement target (9.0+) it was not recognized as deprecated

This adds:
- The deprecation message is now shown
- The deprecation version is shown
- The version a API was introduced is shown

This fixes https://github.com/multi-os-engine/multi-os-engine/issues/168
Related pr: https://github.com/multi-os-engine/moe-binding-clang/pull/2