### PR TITLE
Let NatjGen include nullable information

### DIFF
--- a/src/main/java/org/moe/natjgen/Constants.java
+++ b/src/main/java/org/moe/natjgen/Constants.java
@@ -19,6 +19,7 @@ package org.moe.natjgen;
 public final class Constants {
 
     private static final String NatJPackage = "org.moe.natj";
+    private static final String JetbrainsPackage = "org.jetbrains.annotations";
 
     private static final String GeneralPackage = NatJPackage + ".general";
     private static final String CPackage = NatJPackage + ".c";
@@ -228,6 +229,8 @@ public final class Constants {
     public static final String ObjCProtocolSourceNameAnnotation = "ObjCProtocolSourceName";
     public static final String ProtocolClassMethodAnnotation = "ProtocolClassMethod";
     public static final String SelectorAnnotation = "Selector";
+    public static final String NotNullAnnotation = "NotNull";
+    public static final String NullableAnnotation = "Nullable";
     public static final String XIBAnnotation = "XIB";
 
     public static final String CategoryClassMethodAnnotationFQ =
@@ -253,6 +256,8 @@ public final class Constants {
     public static final String ProtocolClassMethodAnnotationFQ =
             ObjCAnnotationPackage + "." + ProtocolClassMethodAnnotation;
     public static final String SelectorAnnotationFQ = ObjCAnnotationPackage + "." + SelectorAnnotation;
+    public static final String NotNullFQ = JetbrainsPackage + "." + NotNullAnnotation;
+    public static final String NullableFQ = JetbrainsPackage + "." + NullableAnnotation;
     public static final String XIBAnnotationFQ = ObjCAnnotationPackage + "." + XIBAnnotation;
 
     public static final String ObjCCallbackMapper = "ObjCCallbackMapper";

--- a/src/main/java/org/moe/natjgen/ModifierEditor.java
+++ b/src/main/java/org/moe/natjgen/ModifierEditor.java
@@ -182,11 +182,17 @@ public class ModifierEditor extends EditContext {
     };
     private static final String Selector[] = new String[] { Constants.SelectorAnnotation, Constants.SelectorAnnotationFQ
     };
+    private static final String NotNull[] = new String[] { Constants.NotNullAnnotation, Constants.NotNullFQ
+    };
+    private static final String Nullable[] = new String[] { Constants.NullableAnnotation, Constants.NullableFQ
+    };
     private static final String XIB[] = new String[] { Constants.XIBAnnotation, Constants.XIBAnnotationFQ
     };
 
     // Other annotations
     private Annotation aDeprecated;
+
+    private Annotation aNullAnnotation;
 
     private static final String Deprecated[] = new String[] { "Deprecated", null
     };
@@ -747,6 +753,14 @@ public class ModifierEditor extends EditContext {
 
     public void setDeprecated() throws GeneratorException {
         aDeprecated = newMarker(aDeprecated, Deprecated);
+    }
+
+    public void setNullable() throws GeneratorException {
+        aNullAnnotation = newMarker(aNullAnnotation, Nullable);
+    }
+
+    public void setNotNull() throws GeneratorException {
+        aNullAnnotation = newMarker(aNullAnnotation, NotNull);
     }
 
     private Annotation newMarker(Annotation annotation, String type[]) throws GeneratorException {

--- a/src/main/java/org/moe/natjgen/Type.java
+++ b/src/main/java/org/moe/natjgen/Type.java
@@ -19,6 +19,7 @@ package org.moe.natjgen;
 import org.clang.c.clang;
 import org.clang.enums.CXCursorKind;
 import org.clang.enums.CXTypeKind;
+import org.clang.enums.CXTypeNullabilityKind;
 import org.clang.struct.CXCursor;
 import org.clang.struct.CXType;
 import org.eclipse.jdt.core.dom.PrimitiveType;
@@ -210,6 +211,8 @@ public class Type {
      * Signed flag
      */
     private boolean isSignedLong = false;
+
+    private int nullableKind = CXTypeNullabilityKind.Unspecified;
 
     /**
      * Callback type additional data
@@ -596,6 +599,8 @@ public class Type {
         if (type.kind() == CXTypeKind.Elaborated) {
             type = type.getNamedType();
         }
+
+        nullableKind = clang.clang_Type_getNullability(inType);
 
         // Deal with attribute
         type = stripAttribute(type);
@@ -1030,6 +1035,10 @@ public class Type {
 
     public void setKind(int kind) {
         this.kind = kind;
+    }
+
+    public int getNullableKind() {
+        return nullableKind;
     }
 
     /**

--- a/src/main/java/org/moe/natjgen/TypeResolver.java
+++ b/src/main/java/org/moe/natjgen/TypeResolver.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package org.moe.natjgen;
 
+import org.clang.enums.CXTypeNullabilityKind;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ChildPropertyDescriptor;
@@ -199,6 +200,16 @@ public class TypeResolver extends AbstractASTBase {
     }
 
     private void _R() throws GeneratorException {
+        if (type.getNullableKind() == CXTypeNullabilityKind.Nullable || type.getNullableKind() == CXTypeNullabilityKind.NullableResult) {
+            if (modifiers != null) {
+                modifiers.setNullable();
+            }
+        }
+        if (type.getNullableKind() == CXTypeNullabilityKind.NonNull) {
+            if (modifiers != null) {
+                modifiers.setNotNull();
+            }
+        }
         Type root = type.getPonierRootType();
         if (root.getKind() == Type.FullyQualified) {
             _R_FullyQualified();

--- a/src/test/java/org/moe/natjgen/test/protocols/Protocol1.java
+++ b/src/test/java/org/moe/natjgen/test/protocols/Protocol1.java
@@ -12,6 +12,7 @@ public class Protocol1 extends AbstractProtocolTest {
 
         MethodDeclaration[] methods = decl.getMethods();
         assertEquals(2, methods.length);
+        assertHasMarkerAnnotation(methods[0], "org.jetbrains.annotations.Nullable");
 
         assertEquals("prop_1", methods[0].getName().toString());
         assertEquals("TypeProtocol1", methods[0].getReturnType2().toString());
@@ -20,6 +21,7 @@ public class Protocol1 extends AbstractProtocolTest {
         assertEquals("setProp_1", methods[1].getName().toString());
         assertEquals("void", methods[1].getReturnType2().toString());
         assertEquals(1, methods[1].parameters().size());
+        assertHasMarkerAnnotation(((SingleVariableDeclaration)methods[1].parameters().get(0)), "org.jetbrains.annotations.Nullable");
         assertEquals("TypeProtocol1", ((SingleVariableDeclaration)methods[1].parameters().get(0)).getType().toString());
     }
 


### PR DESCRIPTION
This pr will let NatJGen set the jetbrains nullable/notnull marker annotations.
The information is already given on ObjC side so it would be probably best to also reflect the info on the binding side.

~~The only thing I'm worried about is that users that update their bindings also need the "org.jetbrains:annotations:" dependency now. Maybe we can just include the annotations in the moe-core?~~

Related: https://github.com/multi-os-engine/moe-core/pull/7 and https://github.com/multi-os-engine/moe-plugin-gradle/pull/18