### PR TITLE
Parse Macros and generate constants for them

### DIFF
--- a/src/main/java/org/moe/natjgen/Configuration.java
+++ b/src/main/java/org/moe/natjgen/Configuration.java
@@ -1843,6 +1843,7 @@ public class Configuration implements IConfigurationElement {
                 this.pkg = packageName(packageBase, lowercased(framework), "c");
             }
             break;
+            case CXIdxEntityKind.CXIdxEntity_Macro:
             case CXIdxEntityKind.CXIdxEntity_Variable: {
                 this.originalName = this.name = decl.cursor().toString();
                 this.type = C_VARIABLE_TYPE;

--- a/src/main/java/org/moe/natjgen/Generator.java
+++ b/src/main/java/org/moe/natjgen/Generator.java
@@ -440,6 +440,7 @@ public class Generator {
         return cEnumMap.get(identifier);
     }
 
+
     /**
      * Get a {@link CManager} for the given key
      *

--- a/src/main/java/org/moe/natjgen/IModelEditor.java
+++ b/src/main/java/org/moe/natjgen/IModelEditor.java
@@ -105,6 +105,13 @@ interface IModelEditor {
     void processTypedef(CXIdxDeclInfo decl);
 
     /**
+     * Process declaration of macro
+     *
+     * @param decl declaration
+     */
+    void processMacro(CXIdxDeclInfo decl);
+
+    /**
      * Call this before any processing.
      */
     void preProcess();

--- a/src/main/java/org/moe/natjgen/ModelDowngrader.java
+++ b/src/main/java/org/moe/natjgen/ModelDowngrader.java
@@ -446,6 +446,11 @@ class ModelDowngrader extends AbstractModelEditor {
     }
 
     @Override
+    public void processMacro (CXIdxDeclInfo decl) {
+        // TODO Do we need to do something here?
+    }
+
+    @Override
     public void postProcess() {
         super.postProcess();
 

--- a/src/main/java/org/moe/natjgen/Type.java
+++ b/src/main/java/org/moe/natjgen/Type.java
@@ -173,7 +173,7 @@ public class Type {
     /**
      * The resolved kind of the type
      */
-    private final int kind;
+    private int kind;
 
     /**
      * Name of the associated element, present when kind is Objective-C Object,
@@ -1026,6 +1026,10 @@ public class Type {
      */
     public int getKind() {
         return kind;
+    }
+
+    public void setKind(int kind) {
+        this.kind = kind;
     }
 
     /**

--- a/src/test/java/org/moe/natjgen/test/macros/MacrosTest.java
+++ b/src/test/java/org/moe/natjgen/test/macros/MacrosTest.java
@@ -1,0 +1,65 @@
+package org.moe.natjgen.test.macros;
+
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.moe.natjgen.test.AbstractNatJGenTest;
+
+public class MacrosTest extends AbstractNatJGenTest {
+
+    @Override
+    protected void setUp() throws Exception {
+        setUpClass(null, "c/Globals.java", "Globals");
+    }
+
+    public void test_unsigned_int() {
+        FieldDeclaration field = getField("UNSIGNED_INT");
+        assertExistsAndGenerated(field);
+        assertPrimitiveType(field.getType(), "double");
+
+        assertInitialValue(field, "10.0");
+    }
+
+    public void test_signed_int() {
+        FieldDeclaration field = getField("SIGNED_INT");
+        assertExistsAndGenerated(field);
+        assertPrimitiveType(field.getType(), "double");
+
+        assertInitialValue(field, "-10.0");
+    }
+
+    public void test_unsigned_double() {
+        FieldDeclaration field = getField("UNSIGNED_DOUBLE");
+        assertExistsAndGenerated(field);
+        assertPrimitiveType(field.getType(), "double");
+
+        assertInitialValue(field, "10.5");
+    }
+
+    public void test_signed_double() {
+        FieldDeclaration field = getField("SIGNED_DOUBLE");
+        assertExistsAndGenerated(field);
+        assertPrimitiveType(field.getType(), "double");
+
+        assertInitialValue(field, "-10.5");
+    }
+
+    public void test_unsigned_hex_int() {
+        FieldDeclaration field = getField("UNSIGNED_HEX_INT");
+        assertExistsAndGenerated(field);
+        assertPrimitiveType(field.getType(), "double");
+
+        assertInitialValue(field, "91.0");
+    }
+
+    public void test_signed_hex_int() {
+        FieldDeclaration field = getField("SIGNED_HEX_INT");
+        assertExistsAndGenerated(field);
+        assertPrimitiveType(field.getType(), "double");
+
+        assertInitialValue(field, "-91.0");
+    }
+
+    public void test_keyword_skip() {
+        FieldDeclaration field = getField("boolean");
+        assertNull(field);
+    }
+}

--- a/src/test/java/org/moe/natjgen/test/sources/NatJGenTest.java
+++ b/src/test/java/org/moe/natjgen/test/sources/NatJGenTest.java
@@ -164,6 +164,7 @@ public class NatJGenTest {
         copyResource("base_types.h", INCLUDES_DIR);
         copyResource("c_enums.h", INCLUDES_DIR);
         copyResource("c_variables.h", INCLUDES_DIR);
+        copyResource("macros.h", INCLUDES_DIR);
         copyResource("moe_types.h", INCLUDES_DIR);
         copyResource("objc_generics.h", INCLUDES_DIR);
         copyResource("pointers.h", INCLUDES_DIR);

--- a/src/test/resources/all_tests.h
+++ b/src/test/resources/all_tests.h
@@ -17,6 +17,7 @@ limitations under the License.
 #include "base_types.h"
 #include "c_enums.h"
 #include "c_variables.h"
+#include "macros.h"
 #include "pointers.h"
 #include "structs.h"
 

--- a/src/test/resources/macros.h
+++ b/src/test/resources/macros.h
@@ -1,0 +1,12 @@
+#ifndef NATJGEN_TEST_MACROS__H
+#define NATJGEN_TEST_MACROS__H
+
+#define UNSIGNED_INT 10
+#define SIGNED_INT -10
+#define UNSIGNED_DOUBLE 10.5
+#define SIGNED_DOUBLE -10.5
+#define UNSIGNED_HEX_INT 0x5B
+#define SIGNED_HEX_INT -0x5B
+#define boolean 10
+
+#endif /* NATJGEN_TEST_MACROS__H */


### PR DESCRIPTION
~~So this just a draft to show and discuss some progress.~~

~~To get this working I needed to work around the weird null issue with NatJ. I have done this simply by jni:
https://gist.github.com/Berstanio/8b5dfb52744469ecd9d863230549d7c8
The compiled binary just needs to be loaded at runtime.~~ Not needed anymore
~~To get this easier working on java side I made these temporary access modifier changes: https://github.com/Berstanio/moe-binding-clang/commit/993dc88dac0bd519bce51156539b9c606903f598~~ Not needed anymore

This is able to track all value macros ~~in frameworks(!)~~ and generate constants for them.
~~What doesn't work is everything besides frameworks. What also isn't working correctly yet is, that the bindings are also created for frameworks that are indirectly included. Haven't looked really into it yet, how to solve this.~~

Suboptimal is that we parse the code two times. But we can't use the Indexing callbacks for the generation because they don't provide preprocessor infos. We might could change the Index callback base generation to the "visitChildren" based one, but I don't know really how yet.